### PR TITLE
Use unified methods to read primitives from Read

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod model_importer;
 mod normals;
 #[cfg(feature = "obj_import")]
 mod obj;
+mod read_extension;
 #[doc(hidden)]
 pub mod tangents;
 mod tmf;
@@ -70,6 +71,7 @@ pub use crate::vertices::VertexPrecisionMode;
 use std::io::{Read, Write};
 #[doc(inline)]
 pub use verify::TMFIntegrityStatus;
+
 /// Settings for saving of a TMF mesh.
 pub struct TMFPrecisionInfo {
     /// How much can the position of any vertex deviate, as a portion of the shortest edge in the model.

--- a/src/read_extension.rs
+++ b/src/read_extension.rs
@@ -1,0 +1,36 @@
+pub(crate) trait ReadExt {
+    fn read_u8(&mut self) -> std::io::Result<u8>;
+    fn read_u16(&mut self) -> std::io::Result<u16>;
+    fn read_u32(&mut self) -> std::io::Result<u32>;
+    fn read_u64(&mut self) -> std::io::Result<u64>;
+
+    fn read_f64(&mut self) -> std::io::Result<f64>;
+}
+impl<T: std::io::Read> ReadExt for T {
+    fn read_u8(&mut self) -> std::io::Result<u8> {
+        let mut tmp = [0u8];
+        self.read_exact(&mut tmp)?;
+        Ok(tmp[0])
+    }
+    fn read_u16(&mut self) -> std::io::Result<u16> {
+        let mut tmp = [0; std::mem::size_of::<u16>()];
+        self.read_exact(&mut tmp)?;
+        Ok(u16::from_le_bytes(tmp))
+    }
+    fn read_u32(&mut self) -> std::io::Result<u32> {
+        let mut tmp = [0; std::mem::size_of::<u32>()];
+        self.read_exact(&mut tmp)?;
+        Ok(u32::from_le_bytes(tmp))
+    }
+    fn read_u64(&mut self) -> std::io::Result<u64> {
+        let mut tmp = [0; std::mem::size_of::<u64>()];
+        self.read_exact(&mut tmp)?;
+        Ok(u64::from_le_bytes(tmp))
+    }
+
+    fn read_f64(&mut self) -> std::io::Result<f64> {
+        let mut tmp = [0; std::mem::size_of::<f64>()];
+        self.read_exact(&mut tmp)?;
+        Ok(f64::from_le_bytes(tmp))
+    }
+}

--- a/src/tangents.rs
+++ b/src/tangents.rs
@@ -1,6 +1,8 @@
+use crate::read_extension::ReadExt;
 use crate::unaligned_rw::{UnalignedRWMode, UnalignedReader, UnalignedWriter};
 use crate::FloatType;
 use crate::NormalPrecisionMode;
+
 #[derive(Clone, Copy, Debug)]
 /// A value describing handedness of tangent.
 pub struct HandenesType(FloatType);
@@ -90,16 +92,8 @@ pub(crate) fn save_tangents<W: std::io::Write>(
     Ok(())
 }
 pub(crate) fn read_tangents<R: std::io::Read>(src: &mut R) -> std::io::Result<Box<[Tangent]>> {
-    let count = {
-        let mut tmp = [0; std::mem::size_of::<u64>()];
-        src.read_exact(&mut tmp)?;
-        u64::from_le_bytes(tmp)
-    };
-    let bits_prec = {
-        let mut tmp = [0; std::mem::size_of::<u8>()];
-        src.read_exact(&mut tmp)?;
-        u8::from_le_bytes(tmp)
-    };
+    let count = src.read_u64()?;
+    let bits_prec = src.read_u8()?;
     let mut reader = UnalignedReader::new(src);
     let prec = UnalignedRWMode::precision_bits(bits_prec);
     let tan_prec = TangentPrecisionMode::from_bits(bits_prec);

--- a/src/tmf.rs
+++ b/src/tmf.rs
@@ -1,3 +1,4 @@
+use crate::read_extension::ReadExt;
 use crate::tmf_exporter::EncodeInfo;
 use crate::tmf_importer::TMFImportContext;
 use crate::unaligned_rw::{UnalignedRWMode, UnalignedReader};
@@ -130,11 +131,7 @@ impl EncodedSegment {
     ) -> Result<Self, TMFImportError> {
         let seg_type = ctx.segment_type_width().read(src)?;
         let data_length = ctx.segment_length_width().read(src)?;
-        let compresion_type = {
-            let mut tmp = [0];
-            src.read_exact(&mut tmp)?;
-            CompressionType::from_u8(tmp[0])?
-        };
+        let compresion_type = CompressionType::from_u8(src.read_u8()?)?;
         let mut data = vec![0; data_length];
         src.read_exact(&mut data)?;
         Ok(Self {
@@ -195,16 +192,8 @@ fn read_default_triangles<R: std::io::Read>(
     data: &mut Vec<IndexType>,
     ctx: &crate::tmf_importer::TMFImportContext,
 ) -> Result<(), TMFImportError> {
-    let precision_bits = {
-        let mut tmp = [0];
-        src.read_exact(&mut tmp)?;
-        tmp[0]
-    };
-    let length = {
-        let mut tmp = [0; std::mem::size_of::<u64>()];
-        src.read_exact(&mut tmp)?;
-        u64::from_le_bytes(tmp)
-    };
+    let precision_bits = src.read_u8()?;
+    let length = src.read_u64()?;
     let min = ctx.read_traingle_min(&mut src)?;
     if length > MAX_SEG_SIZE as u64 {
         return Err(TMFImportError::SegmentTooLong);
@@ -278,7 +267,7 @@ fn calc_spilt_score(len: usize, delta_span: (IndexType, IndexType)) -> isize {
         ((TMF_SEG_SIZE + std::mem::size_of::<u8>() + std::mem::size_of::<u32>()) * 8) as isize;
     gain - loss
 }
-fn search_for_sequential_regions(triangles:&[IndexType]){
+fn search_for_sequential_regions(triangles: &[IndexType]) {
     /*
     let mut last = 0;
     let mut span_start = 0;

--- a/src/tmf_importer.rs
+++ b/src/tmf_importer.rs
@@ -1,6 +1,10 @@
+use std::io::Read;
+
+use crate::read_extension::ReadExt;
 use crate::tmf::{DecodedSegment, EncodedSegment, SectionType};
 use crate::{TMFImportError, TMFMesh, TMF_MAJOR, TMF_MINOR};
 use futures::future::join_all;
+
 #[derive(Clone, Copy)]
 pub(crate) enum SegLenWidth {
     U32,
@@ -14,18 +18,10 @@ impl SegLenWidth {
             Self::U64
         }
     }
-    pub(crate) fn read<R: std::io::Read>(&self, src: &mut R) -> std::io::Result<usize> {
+    pub(crate) fn read<R: Read>(&self, src: &mut R) -> std::io::Result<usize> {
         Ok(match self {
-            Self::U32 => {
-                let mut tmp = [0; std::mem::size_of::<u32>()];
-                src.read_exact(&mut tmp)?;
-                u32::from_le_bytes(tmp) as usize
-            }
-            Self::U64 => {
-                let mut tmp = [0; std::mem::size_of::<u64>()];
-                src.read_exact(&mut tmp)?;
-                u64::from_le_bytes(tmp) as usize
-            }
+            Self::U32 => src.read_u32()? as usize,
+            Self::U64 => src.read_u64()? as usize,
         })
     }
 }
@@ -42,18 +38,10 @@ impl SegTypeWidth {
             Self::U16
         }
     }
-    pub(crate) fn read<R: std::io::Read>(&self, src: &mut R) -> std::io::Result<SectionType> {
+    pub(crate) fn read<R: Read>(&self, src: &mut R) -> std::io::Result<SectionType> {
         Ok(match self {
-            Self::U8 => {
-                let mut tmp = [0; std::mem::size_of::<u8>()];
-                src.read_exact(&mut tmp)?;
-                SectionType::from_u8(u8::from_le_bytes(tmp))
-            }
-            Self::U16 => {
-                let mut tmp = [0; std::mem::size_of::<u16>()];
-                src.read_exact(&mut tmp)?;
-                SectionType::from_u16(u16::from_le_bytes(tmp))
-            }
+            Self::U8 => SectionType::from_u8(src.read_u8()?),
+            Self::U16 => SectionType::from_u16(src.read_u16()?),
         })
     }
 }
@@ -71,12 +59,8 @@ struct TMFHeader {
     min_major: u16,
     min_minor: u16,
 }
-pub(crate) fn read_string<R: std::io::Read>(src: &mut R) -> std::io::Result<String> {
-    let byte_len = {
-        let mut tmp = [0; std::mem::size_of::<u16>()];
-        src.read_exact(&mut tmp)?;
-        u16::from_le_bytes(tmp)
-    };
+pub(crate) fn read_string<R: Read>(src: &mut R) -> std::io::Result<String> {
+    let byte_len = src.read_u16()?;
     let mut bytes = vec![0; byte_len as usize];
     src.read_exact(&mut bytes)?;
     match std::str::from_utf8(&bytes) {
@@ -87,33 +71,18 @@ pub(crate) fn read_string<R: std::io::Read>(src: &mut R) -> std::io::Result<Stri
         )),
     }
 }
-async fn read_tmf_header<R: std::io::Read>(src: &mut R) -> Result<TMFHeader, TMFImportError> {
+async fn read_tmf_header<R: Read>(src: &mut R) -> Result<TMFHeader, TMFImportError> {
     let mut magic = [0; 3];
     src.read_exact(&mut magic)?;
     if magic != *b"TMF" {
         return Err(TMFImportError::NotTMFFile);
     }
-    let major = {
-        let mut tmp = [0; std::mem::size_of::<u16>()];
-        src.read_exact(&mut tmp)?;
-        u16::from_le_bytes(tmp)
-    };
-    let minor = {
-        let mut tmp = [0; std::mem::size_of::<u16>()];
-        src.read_exact(&mut tmp)?;
-        u16::from_le_bytes(tmp)
-    };
+    let major = src.read_u16()?;
+    let minor = src.read_u16()?;
     // Minimum version of reader required to read
-    let min_major = {
-        let mut tmp = [0; std::mem::size_of::<u16>()];
-        src.read_exact(&mut tmp)?;
-        u16::from_le_bytes(tmp)
-    };
-    let min_minor = {
-        let mut tmp = [0; std::mem::size_of::<u16>()];
-        src.read_exact(&mut tmp)?;
-        u16::from_le_bytes(tmp)
-    };
+    let min_major = src.read_u16()?;
+    let min_minor = src.read_u16()?;
+
     if min_major > TMF_MAJOR || (min_major == TMF_MAJOR && min_minor > TMF_MINOR) {
         Err(TMFImportError::NewerVersionRequired)
     } else {
@@ -132,35 +101,28 @@ impl TMFImportContext {
     pub(crate) fn segment_length_width(&self) -> &SegLenWidth {
         &self.segment_length_width
     }
-    pub(crate) fn read_traingle_min<R: std::io::Read>(&self, src: &mut R) -> std::io::Result<u64> {
+    pub(crate) fn read_traingle_min<R: Read>(&self, src: &mut R) -> std::io::Result<u64> {
         if self.should_read_min_index {
-            let mut tmp = [0; std::mem::size_of::<u64>()];
-            src.read_exact(&mut tmp)?;
-            Ok(u64::from_le_bytes(tmp))
+            src.read_u64()
         } else {
             Ok(0)
         }
     }
     fn init_header(hdr: TMFHeader) -> Self {
-        let segment_length_width = SegLenWidth::from_header(&hdr);
-        let segment_type_width = SegTypeWidth::from_header(&hdr);
         Self {
-            segment_length_width,
-            segment_type_width,
+            segment_length_width: SegLenWidth::from_header(&hdr),
+            segment_type_width: SegTypeWidth::from_header(&hdr),
             should_read_min_index: (hdr.min_minor > 1),
         }
     }
-    async fn import_mesh<R: std::io::Read>(
+    async fn import_mesh<R: Read>(
         &self,
         mut src: R,
-        ctx: &crate::tmf_importer::TMFImportContext,
+        ctx: &Self,
     ) -> Result<(TMFMesh, String), TMFImportError> {
         let name = read_string(&mut src)?;
-        let segment_count = {
-            let mut tmp = [0; std::mem::size_of::<u16>()];
-            src.read_exact(&mut tmp)?;
-            u16::from_le_bytes(tmp)
-        }; //self.segment_length_width.read(&mut src)?;
+        let segment_count = src.read_u16()?;
+        //self.segment_length_width.read(&mut src)?;
         let mut decoded_segs = Vec::with_capacity(segment_count as usize);
         for _ in 0..segment_count {
             let encoded = EncodedSegment::read(self, &mut src)?;
@@ -181,17 +143,9 @@ impl TMFImportContext {
             });
         Ok((res, name))
     }
-    async fn analize_mesh<R: std::io::Read>(
-        &self,
-        mut src: R,
-        ctx: &crate::tmf_importer::TMFImportContext,
-    ) -> Result<(), TMFImportError> {
+    async fn analize_mesh<R: Read>(&self, mut src: R, ctx: &Self) -> Result<(), TMFImportError> {
         let name = read_string(&mut src)?;
-        let segment_count = {
-            let mut tmp = [0; std::mem::size_of::<u16>()];
-            src.read_exact(&mut tmp)?;
-            u16::from_le_bytes(tmp)
-        };
+        let segment_count = src.read_u16()?;
         let mut results = [0; 256];
         for _ in 0..segment_count {
             let encoded = EncodedSegment::read(self, &mut src)?;
@@ -210,39 +164,29 @@ impl TMFImportContext {
         println!("res:{res:?}, total_len:{total}");
         Ok(())
     }
-    pub(crate) async fn import<R: std::io::Read>(
+    pub(crate) async fn import<R: Read>(
         mut src: R,
     ) -> Result<Vec<(TMFMesh, String)>, TMFImportError> {
         let header = read_tmf_header(&mut src).await?;
         let res = Self::init_header(header);
-        let mesh_count = {
-            let mut tmp = [0; std::mem::size_of::<u32>()];
-            src.read_exact(&mut tmp)?;
-            u32::from_le_bytes(tmp)
-        };
+        let mesh_count = src.read_u32()?;
         let mut meshes = Vec::with_capacity((u16::MAX as usize).min(mesh_count as usize));
         for _ in 0..mesh_count {
             meshes.push(res.import_mesh(&mut src, &res).await?);
         }
         Ok(meshes)
     }
-    pub(crate) async fn analize<R: std::io::Read>(mut src: R) -> Result<(), TMFImportError> {
+    pub(crate) async fn analize<R: Read>(mut src: R) -> Result<(), TMFImportError> {
         let header = read_tmf_header(&mut src).await?;
         let res = Self::init_header(header);
-        let mesh_count = {
-            let mut tmp = [0; std::mem::size_of::<u32>()];
-            src.read_exact(&mut tmp)?;
-            u32::from_le_bytes(tmp)
-        };
+        let mesh_count = src.read_u32()?;
         for _ in 0..mesh_count {
             res.analize_mesh(&mut src, &res).await?;
         }
         Ok(())
     }
 }
-pub(crate) fn import_sync<R: std::io::Read>(
-    src: R,
-) -> Result<Vec<(TMFMesh, String)>, TMFImportError> {
+pub(crate) fn import_sync<R: Read>(src: R) -> Result<Vec<(TMFMesh, String)>, TMFImportError> {
     crate::tmf::RUNTIME.block_on(TMFImportContext::import(src))
 }
 #[cfg(test)]

--- a/src/unaligned_rw.rs
+++ b/src/unaligned_rw.rs
@@ -3,6 +3,7 @@ use std::io::{BufWriter, Read, Result, Write};
 type UnalignedStorage = usize;
 #[cfg(feature = "byte_rw")]
 type UnalignedStorage = usize;
+
 const UNALIGNED_STORAGE_BITS: u8 = (std::mem::size_of::<UnalignedStorage>() * 8) as u8;
 pub struct UnalignedReader<R: Read> {
     /// Buff Reader used to speedup reads in some cases.

--- a/src/uv.rs
+++ b/src/uv.rs
@@ -1,3 +1,4 @@
+use crate::read_extension::ReadExt;
 use crate::unaligned_rw::{UnalignedRWMode, UnalignedReader, UnalignedWriter};
 use crate::TMFImportError;
 use crate::MAX_SEG_SIZE;
@@ -50,16 +51,8 @@ pub fn save_uvs<W: Write>(
     Ok(())
 }
 pub fn read_uvs<R: Read>(reader: &mut R) -> Result<Box<[Vector2]>, TMFImportError> {
-    let precision = {
-        let mut tmp = [0];
-        reader.read_exact(&mut tmp)?;
-        tmp[0]
-    };
-    let count = {
-        let mut tmp = [0; std::mem::size_of::<u64>()];
-        reader.read_exact(&mut tmp)?;
-        u64::from_le_bytes(tmp)
-    };
+    let precision = reader.read_u8()?;
+    let count = reader.read_u64()?;
     if count > MAX_SEG_SIZE as u64 {
         return Err(TMFImportError::SegmentTooLong);
     }


### PR DESCRIPTION
This removes a bit of the boilerplate around reading primitives from std::io::Read.

This trims about 90 lines from the source, making it a bit more accessible.

The lines in question are also fairly tricky to read and unrelated to surrounding code, so this helps too.

Alternative
-----------

An alternative would be not to define those methods as a trait extension for Read, but rather as free functions. Then you would simply call them.

This method is not inferior to the one I chose. But trait extensions are more rusty.