### PR TITLE
Make tokio dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,19 +9,22 @@ repository = "https://github.com/FractalFir/tmf"
 authors = ["FractalFir <fractalfirdev@gmail.com>"]
 keywords = ["graphics","3D","compression","lossy","gamedev"]
 categories = ["game-development","rendering::data-formats","compression"]
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 ##! Test
 [dependencies]
 document-features = "0.2.7"
 futures = { version = "0.3.28" }
-lazy_static = "1.4.0"
+lazy_static = { version = "1.4.0", optional = true }
 smallvec = "1.10.0"
-tokio = { version = "1.28.1", features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1.28.1", features = ["rt", "rt-multi-thread"], optional = true }
+
 [dev-dependencies]
 criterion = "0.5.1"
 rand = "0.8.5"
+
 [features]
-default = ["obj_import"]
+default = ["obj_import", "tokio_runtime"]
+
 ## Experimental triangulation in .obj loader. Supports only convex polygons ATM, and has bugs, triangulating your mesh in 3D modelling software before importing highly advised. Please note that if you see any triangles missing this is likely the result of the triangulation algorithm not working properly. 
 triangulation = []
 ## Changes the sin and cos function used in reading the tmf files for a potentially faster, but less accurate functions.
@@ -35,8 +38,12 @@ short_indices = []
 ## Changes the internal setting of the unaligned reader to use different data size. Can be beneficial for small models on some systems.
 byte_rw = []
 model_importer = []
-## Adds the ability to import/export .obj files
+
+## Adds the ability to import/export .obj files. Enabled by default
 obj_import = ["model_importer"]
+
+## Use the tokio runtime, significantly increasing performance of synchronous loads, at the cost of minor compile time increase. Enabled by default.
+tokio_runtime = ["tokio", "lazy_static"]
 
 [[bench]]
 name = "unaligned_rw"

--- a/src/tmf.rs
+++ b/src/tmf.rs
@@ -5,9 +5,6 @@ use crate::{
     CustomDataSegment, FloatType, IndexType, TMFExportError, TMFImportError, TMFMesh,
     TMFPrecisionInfo, Tangent, Vector2, Vector3, MAX_SEG_SIZE,
 };
-lazy_static::lazy_static! {
-    pub(crate) static ref RUNTIME:tokio::runtime::Runtime = tokio::runtime::Runtime::new().unwrap();
-}
 use smallvec::{smallvec, SmallVec};
 #[repr(u16)]
 #[derive(Debug, PartialEq, Clone, Copy)]


### PR DESCRIPTION
Tokio is a fairly heavy dependency. Some people might be interested in using a different async runtime while still using tmf. We feature-gate tokio so that end-users do not end up having several async runtimes bundled in their software.

Note that this isn't how I'd implement it. I would much prefer implementing (2) in the following list of alternatives. But I wasn't sure such a PR would be accepted, and it's a fairly large commitment.

Alternatives
============

1. **Remove `tmf_importer::import_sync`**

Since this is the only bit of code that depends on tokio, we could just remove it.

However, this requires excising a large part of the API, meaning: all sync readers. I preferred providing a degraded version of the sync reader. Supposedly, a user who cares about the async runtime will use the async loading methods, and won't use the sync ones.

This is also a much more invasive change, and I didn't want to make such a change without at least a signal this would be accepted.

2. **Make `tmf` generic over the runtime**

We could let users specify a runtime. This would make the loader generic over `T: Runtime` with `Runtime` a trait with a `block_on` method.

This is also a very invasive change, and I restrained myself for the reasons I already mentioned.

3. **Remove all async code**

tmf uses blocking IO, so it doesn't benefit much from an async loader. The only async functionality used is `future::join_all`, which I assume is just a way to use parallelism. So why bother? Let's just not make the functions async.

The disadvantage of course is that now we can't use parallelism in the loader. To introduce it back, we could accept a thread pool variable or type parameter, but the implementation would then look similar — if not identical — to the `T: Runtime` suggestion from (2).

This is also a very invasive change.

4. **Provide a sync version of all async methods**

This is similar to (3), but instead of removing the async code, we copy/paste the implementations and provide non-async versions of the functions in question.

This isn't DRY, and we still lose parallelism on the sync implementation, so I don't think it's a viable alternative.

This is also a very invasive change.

Thoughts? Opinions?