### PR TITLE
Add Error impl for TMF error types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ document-features = "0.2.7"
 futures = { version = "0.3.28" }
 lazy_static = { version = "1.4.0", optional = true }
 smallvec = "1.10.0"
+thiserror = "1"
 tokio = { version = "1.28.1", features = ["rt", "rt-multi-thread"], optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@ pub use crate::uv::UvPrecisionMode;
 #[doc(inline)]
 pub use crate::vertices::VertexPrecisionMode;
 use std::io::{Read, Write};
+use thiserror::Error;
 #[doc(inline)]
 pub use verify::TMFIntegrityStatus;
 
@@ -857,42 +858,34 @@ impl TMFMesh {
     }
 }
 /// An enum describing an error that occurred during loading a TMF mesh.  
-#[derive(Debug)]
+#[derive(Debug, Error)]
+#[allow(missing_docs)] // allow: documentation is redundant with #[error] attributes.
 pub enum TMFImportError {
-    /// An IO error which prevented data from being read.
-    IO(std::io::Error),
-    /// A segment uses an unknown compression type, invalid for the minimum TMF version specified by file header.
+    #[error("tmf data couldn't be read")]
+    IO(#[from] std::io::Error),
+    #[error("A segment uses an unknown compression type ({0}), invalid for the minimum TMF version specified by file header.")]
     CompressionTypeUnknown(u8),
-    /// A method which should return one mesh was called, but TMF file had no meshes present.
+    #[error("A method returning one mesh was called, but TMF file had no meshes present.")]
     NoMeshes,
-    /// A method which should return one mesh was called, but more than one mesh was present.
+    #[error("A method returning one mesh was called, but more than one mesh was present.")]
     TooManyMeshes,
-    /// Provides source was not a TMF file.
+    #[error("Source file was not a TMF file.")]
     NotTMFFile,
-    /// File was created with a TMF version newer than this, and can't be read properly.
+    #[error("File was created with a TMF version newer than this, and can't be read properly.")]
     NewerVersionRequired,
-    /// A file segment exceeded the maximum length(2GB) was encountered. This segments length is highly unusual, and the segment unlikely to be valid. The segment was not read to prevent memory issues.
+    #[error("A file segment exceeded the maximum length(2GB) was encountered. This segments length is highly unusual, and the segment unlikely to be valid. The segment was not read to prevent memory issues.")]
     SegmentTooLong,
-    /// A segments compression type requires that it must be preceded by another segment, from which some of the data is deduced.   
+    #[error("A segments compression type requires that it must be preceded by another segment, from which some of the data is deduced.   ")]
     NoDataBeforeOmmitedSegment,
-    /// Byte precision is too high(over 64 bits) and is invalid.
+    #[error("Byte precision is too high ({0}: over 64 bits) and is invalid.")]
     InvalidPrecision(u8),
 }
-impl From<std::io::Error> for TMFImportError {
-    fn from(err: std::io::Error) -> Self {
-        Self::IO(err)
-    }
-}
 /// An error which occured when a `TMFMesh` is exported.
-#[derive(Debug)]
+#[derive(Debug, Error)]
+#[allow(missing_docs)] // allow: documentation is redundant with #[error] attributes.
 pub enum TMFExportError {
-    /// An IO error which prevented data from being read.
-    IO(std::io::Error),
-}
-impl From<std::io::Error> for TMFExportError {
-    fn from(err: std::io::Error) -> Self {
-        Self::IO(err)
-    }
+    #[error("tmf data couldn't be written")]
+    IO(#[from] std::io::Error),
 }
 #[cfg(test)]
 pub(crate) fn init_test_env() {


### PR DESCRIPTION
When using tmf, I would like to use the `?` operator on Results returned by tmf methods.

It is currently impossible to do so, because `TMFImportError` and `TMFExportError` do not implement `Error` (unlike their name suggest).

To fix this, we implement `Error` on TMF types using the thiserror derive macro.

Alternatives
------------

Instead of using thiserror, it's possible to define yourself the `Error` implementation. But thiserror is _widely used_ in the rust ecosystem, and it's fairly tedious (and error-prone) to manually implement `Error`.

There are two drawbacks to using thiserror:

- Compile time are certainly increased (but not by much!) from using a proc_macro crate
- It's an additional dependency to worry about

I still think using thiserror is worthwhile. Also considering that it will probably end up in the user's dependency tree regardless.

But if you prefer a manual impl, please tell me so that I can submit a better patch.